### PR TITLE
Improve Button UI

### DIFF
--- a/FineRoadTool/UIToolOptionsButton.cs
+++ b/FineRoadTool/UIToolOptionsButton.cs
@@ -105,6 +105,7 @@ namespace FineRoadTool
                     m_tunnelModeButton.SimulateClick();
                     break;
             }
+            if (isChecked) m_button.normalFgSprite = m_button.normalFgSprite + "Focused";
         }
 
         private void CreateButton()

--- a/FineRoadTool/UIToolOptionsButton.cs
+++ b/FineRoadTool/UIToolOptionsButton.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 using ColossalFramework;
 using ColossalFramework.UI;
@@ -122,7 +122,7 @@ namespace FineRoadTool
             m_button.playAudioEvents = true;
             m_button.relativePosition = Vector2.zero;
 
-            m_button.tooltip = "Fine Road Tool " + ModInfo.version + "\n\nClick here for Tool Options";
+            m_button.tooltip = "Fine Road Tool";
 
             m_button.textColor = Color.white;
             m_button.textScale = 0.7f;

--- a/FineRoadTool/UIToolOptionsButton.cs
+++ b/FineRoadTool/UIToolOptionsButton.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 using ColossalFramework;
 using ColossalFramework.UI;
@@ -79,58 +79,44 @@ namespace FineRoadTool
                 return;
             }
 
-            m_button.text = m_elevationStepLabel.text = FineRoadTool.instance.elevationStep + "m\n";
             m_elevationStepSlider.value = FineRoadTool.instance.elevationStep;
             m_straightSlope.isChecked = FineRoadTool.instance.straightSlope;
-
-            m_button.normalFgSprite = FineRoadTool.instance.straightSlope ? "ToolbarIconGroup1Hovered" : null;
 
             switch (FineRoadTool.instance.mode)
             {
                 case Mode.Normal:
-                    m_button.text += "Nrm\n";
+                    m_button.normalFgSprite = "NormalMode";
                     m_normalModeButton.SimulateClick();
                     break;
                 case Mode.Ground:
-                    m_button.text += "Gnd\n";
+                    m_button.normalFgSprite = "GroundMode";
                     m_groundModeButton.SimulateClick();
                     break;
                 case Mode.Elevated:
-                    m_button.text += "Elv\n";
+                    m_button.normalFgSprite = "ElevatedMode";
                     m_elevatedModeButton.SimulateClick();
                     break;
                 case Mode.Bridge:
-                    m_button.text += "Bdg\n";
+                    m_button.normalFgSprite = "BridgeMode";
                     m_bridgeModeButton.SimulateClick();
                     break;
                 case Mode.Tunnel:
-                    m_button.text += "Tnl\n";
+                    m_button.normalFgSprite = "TunnelMode";
                     m_tunnelModeButton.SimulateClick();
                     break;
             }
-
-            m_button.text += FineRoadTool.instance.elevation + "m";
         }
 
         private void CreateButton()
         {
             m_button = AddUIComponent<UIButton>();
-            m_button.atlas = ResourceLoader.GetAtlas("Ingame");
+            m_button.atlas = m_atlas;
             m_button.name = "FRT_MainButton";
             m_button.size = new Vector2(36, 36);
-            m_button.textScale = 0.7f;
             m_button.playAudioEvents = true;
             m_button.relativePosition = Vector2.zero;
 
             m_button.tooltip = "Fine Road Tool";
-
-            m_button.textColor = Color.white;
-            m_button.textScale = 0.7f;
-            m_button.dropShadowOffset = new Vector2(2, -2);
-            m_button.useDropShadow = true;
-
-            m_button.textHorizontalAlignment = UIHorizontalAlignment.Center;
-            m_button.wordWrap = true;
 
             m_button.normalBgSprite = "OptionBase";
             m_button.hoveredBgSprite = "OptionBaseHovered";


### PR DESCRIPTION
I think most people can agree that right now the button within the road tool seems out of place and odd. Well I'm here to fix that!

I changed the tooltip to just say the mod name. This is for a couple reasons: 1) the tooltip is supposed to be a very very very short (like 3 words short) descriptor of what the button is. For example, the straight road says "Straight Road", curved says "Curved Road," the advisor says "Advisor," and so on. 2) there's no reason to display the mod version in the tooltip. If we need to find out, we should look at the Content Manager where every other mod's version is. 3) it was just really long. We don't need instructions in the tooltip; those can be in the menu itself or on the steam workshop page. 

I removed the text of the button and replaced it with the icon of the selected option. This makes sense for various reasons. The major ones being: 1) consistency; it feels way more consistent with the other buttons and really fits in well, 2) appearance; imho, it looks a lot better, and 3) usability; it's quick and easy to identify if you've got any settings enabled the next time you go to build a road. Just glance and you recognize the icon, instead of having to read tiny text.

Hope this gets merged, I'd love to see these improvements implemented :)

P.S. I did not up the version, in case you'd want to do it.